### PR TITLE
Fix #47: Enforce a more consistent header size across the site.

### DIFF
--- a/oneanddone/base/static/css/one-and-done.less
+++ b/oneanddone/base/static/css/one-and-done.less
@@ -15,8 +15,17 @@
 * {
     .border-box();
 }
-h1, h2 {
-    font-weight: bold;
+h1, .billboard h1 {
+    font-size: 48px;
+}
+h2, .billboard h2 {
+    font-size: 32px;
+}
+h3, .billboard h3 {
+    font-size: 28px;
+}
+h4, .billboard h4 {
+    font-size: 24px;
 }
 p {
     line-height: 1.5;
@@ -63,6 +72,10 @@ footer {
     min-height: 240px;
     .border-radius(.4rem);
     .box-shadow(2px 2px 8px #999);
+
+    h2 {
+        font-weight: bold;
+    }
 }
 .auth-menu {
     margin-right: 2%;
@@ -110,8 +123,11 @@ footer {
     padding-top: 2rem;
 }
 .markdown {
-    h2 {
-        font-size: 2.5rem;
+    ul, ol {
+        margin-left: 1rem;
+        li > p {
+            margin: 0;
+        }
     }
 }
 .actions-container {
@@ -185,7 +201,6 @@ footer {
 .task-list {
     h4 {
         margin-bottom: 6px;
-        font-size: 1.4rem;
     }
     li {
         list-style-type: none;

--- a/oneanddone/tasks/templates/tasks/available.html
+++ b/oneanddone/tasks/templates/tasks/available.html
@@ -28,7 +28,7 @@
       {% for task in available_tasks %}
         <li>
           <h4>{{ task_area_tree(task.area) }}</h4>
-          <p><a href="{{ task.get_absolute_url() }}">{{ task.name }} {{ task.id }}</a></p>
+          <p><a href="{{ task.get_absolute_url() }}">{{ task.name }}</a></p>
           <p>{{ task.short_description }}</p>
         </li>
       {% endfor %}


### PR DESCRIPTION
This is a stopgap. Long-term we're going to need to clean up the CSS
across the site, as our less files are kind've a mess right now.

Also fixes up list spacing in task details.
