### PR TITLE
Switch API to use auth tokens instead of basic auth

### DIFF
--- a/oneanddone/settings/base.py
+++ b/oneanddone/settings/base.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = (
     'mptt',
     'product_details',
     'rest_framework',
+    'rest_framework.authtoken',
     'south',
     'tower',
     'session_csrf',
@@ -157,8 +158,11 @@ SUPPORTED_NONLOCALES.append('api')
 # Permissions for the REST api
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAdminUser',
+        'rest_framework.permissions.IsAuthenticated',
         'rest_framework.permissions.DjangoModelPermissions',
+    ),
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
     )
 }
 

--- a/oneanddone/tasks/mixins.py
+++ b/oneanddone/tasks/mixins.py
@@ -1,6 +1,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from django.core.exceptions import PermissionDenied
+
 from oneanddone.tasks.models import Task
 
 
@@ -14,3 +16,14 @@ class TaskMustBePublishedMixin(object):
     def get_queryset(self):
         queryset = super(TaskMustBePublishedMixin, self).get_queryset()
         return queryset.filter(Task.is_available_filter(allow_expired=self.allow_expired_tasks))
+
+
+class APIRecordCreatorMixin(object):
+    def pre_save(self, obj):
+        obj.creator = self.request.user
+
+
+class APIOnlyCreatorMayDeleteMixin(object):
+    def pre_delete(self, obj):
+        if obj.creator != self.request.user:
+            raise PermissionDenied()

--- a/oneanddone/tasks/views.py
+++ b/oneanddone/tasks/views.py
@@ -12,6 +12,7 @@ from tower import ugettext as _
 from oneanddone.base.util import get_object_or_none
 from oneanddone.tasks.filters import AvailableTasksFilterSet
 from oneanddone.tasks.forms import FeedbackForm
+from oneanddone.tasks.mixins import APIRecordCreatorMixin, APIOnlyCreatorMayDeleteMixin
 from oneanddone.tasks.mixins import TaskMustBePublishedMixin
 from oneanddone.tasks.models import Feedback, Task, TaskArea, TaskAttempt
 from oneanddone.tasks.serializers import TaskSerializer, TaskAreaSerializer
@@ -107,21 +108,23 @@ class CreateFeedbackView(UserProfileRequiredMixin, TaskMustBePublishedMixin, gen
         return redirect('users.profile.detail')
 
 
-class TaskListAPI(generics.ListCreateAPIView):
+class TaskListAPI(APIRecordCreatorMixin, generics.ListCreateAPIView):
     queryset = Task.objects.all()
     serializer_class = TaskSerializer
 
 
-class TaskDetailAPI(generics.RetrieveUpdateDestroyAPIView):
+class TaskDetailAPI(APIOnlyCreatorMayDeleteMixin,
+                    generics.RetrieveUpdateDestroyAPIView):
     queryset = Task.objects.all()
     serializer_class = TaskSerializer
 
 
-class TaskAreaListAPI(generics.ListCreateAPIView):
+class TaskAreaListAPI(APIRecordCreatorMixin, generics.ListCreateAPIView):
     queryset = TaskArea.objects.all()
     serializer_class = TaskAreaSerializer
 
 
-class TaskAreaDetailAPI(generics.RetrieveUpdateDestroyAPIView):
+class TaskAreaDetailAPI(APIOnlyCreatorMayDeleteMixin,
+                        generics.RetrieveUpdateDestroyAPIView):
     queryset = TaskArea.objects.all()
     serializer_class = TaskAreaSerializer

--- a/oneanddone/users/migrations/0001_initial.py
+++ b/oneanddone/users/migrations/0001_initial.py
@@ -7,6 +7,10 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
+    needed_by = (
+        ('authtoken', '0001_initial'),
+    )
+
     def forwards(self, orm):
         # Adding model 'UserProfile'
         db.create_table('users_userprofile', (


### PR DESCRIPTION
@Osmose: I realized that using basic auth and relying on admin users for the API is going to be a problem for contributors. They wouldn't be able to run the tests themselves and that's a big issue.

This PR changes the auth method to use an api token, which is a feature that is supported by Django REST Framework. An administrator can create an api token for a user via the admin site, and then that user can use the api token to authorize access to the API. I believe this is how the permissions for the Moztrap API work, but I am trying to find out from @camd.

As we won't need the API at all in production, before this goes to production we should look at the best way of disabling the API in production. One option would be to create a [Custom Permission class](http://django-rest-framework.org/api-guide/permissions#custom-permissions) which looks at the url requested and denies anything with `mozilla` in it. That's just one idea ottomh - I am sure you have better ideas.

Please let me know if you have any issues with this approach / PR as I am currently writing some base tests that make use of the API this way.

Note also that after these changes are applied you'll need to run syncdb and migrate to pick up the new table.
