### PR TITLE
Added hyper links for different  QA teams

### DIFF
--- a/oneanddone/base/templates/base/home.html
+++ b/oneanddone/base/templates/base/home.html
@@ -34,15 +34,19 @@
     <h3 class="teams-heading">{{ _('Our Teams') }}</h3>
     <div class="teams-top-row">
       <section class="automation-section">
-        <h4 class="automation-heading">{{ _('Automation') }}</h4>
-        <p>
+        <h4 class="automation-heading">
+	  <a href="https://quality.mozilla.org/teams/automation/">{{ _('Automation') }}</a>
+	</h4>
+	<p>
           {% trans %}
             We build automated tests to run against Mozilla websites to make sure they are working as expected.
           {% endtrans %}
         </p>
       </section>
       <section class="desktopqa-section">
-        <h4 class="desktopqa-heading">{{ _('Desktop QA') }}</h4>
+        <h4 class="desktopqa-heading">
+	  <a href="https://quality.mozilla.org/teams/desktop-firefox/">{{ _('Desktop QA') }}</a>
+	</h4>
         <p>
           {% trans %}
             We test Desktop Firefox for new features and resolved issues before release.
@@ -50,7 +54,9 @@
         </p>
       </section>
       <section class="webqa-section">
-        <h4 class="webqa-heading">{{ _('Web QA') }}</h4>
+        <h4 class="webqa-heading">
+	  <a href="https://quality.mozilla.org/teams/web-qa/">{{ _('Web QA') }}</a>
+	</h4>
         <p>
           {% trans %}
             We ensure that all Mozilla websites are high quality, secure, and user friendly.
@@ -61,7 +67,9 @@
 
     <div class="teams-bottom-row">
       <section class="thunderbird-section">
-        <h4 class="thunderbird-heading">Thunderbird</h4>
+        <h4 class="thunderbird-heading">
+	  <a href="https://quality.mozilla.org/teams/thunderbird/">Thunderbird</a>
+	</h4>
         <p>
           {% trans %}
             We test the Thunderbird mail client for resolved issues before release.
@@ -69,7 +77,9 @@
         </p>
       </section>
       <section class="servicesqa-section">
-        <h4 class="servicesqa-heading">{{ _('Services QA') }}</h4>
+        <h4 class="servicesqa-heading">
+	  <a href="https://quality.mozilla.org/teams/services/">{{ _('Services QA') }}</a>
+	</h4>
         <p>
           {% trans %}
             We test Mozilla's private and secure user-controlled services for Firefox, desktop and mobile.
@@ -77,7 +87,9 @@
         </p>
       </section>
       <section class="mobilefx-section">
-        <h4 class="mobilefx-heading">{{ _('Mobile Firefox') }}</h4>
+        <h4 class="mobilefx-heading">
+	  <a href="https://quality.mozilla.org/teams/mobile/">{{ _('Mobile Firefox') }}</a>
+	</h4>
         <p>
           {% trans %}
             We test Firefox for Android and Firefox OS, a new mobile operating system.


### PR DESCRIPTION
 Issue #103 : Links not Present in "Our Teams" Section.

Added Links for every team for  getting more details about those teams.

Signed-off-by: Ashish Namdev ashish28.sirt@gmail.com
