### PR TITLE
Add logging for django-browserid

### DIFF
--- a/oneanddone/settings/base.py
+++ b/oneanddone/settings/base.py
@@ -225,3 +225,18 @@ INSTRUCTIONS_ALLOWED_ATTRIBUTES = {
 
 # Google Analytics ID
 GOOGLE_ANALYTICS_ID = ''
+
+LOGGING = {
+   'handlers': {
+       'console':{
+           'level': 'DEBUG',
+           'class': 'logging.StreamHandler'
+       },
+   },
+   'loggers': {
+       'django_browserid': {
+           'handlers': ['console'],
+           'level': 'DEBUG',
+       }
+   },
+}


### PR DESCRIPTION
Trying to figure out why django-browserid v 0.10.1 won't work on Stackato. Perhaps this logging will help?

@Osmose: r?
