### PR TITLE
Fix bug where an empty keyword is added to a task

### DIFF
--- a/oneanddone/tasks/forms.py
+++ b/oneanddone/tasks/forms.py
@@ -36,7 +36,8 @@ class TaskForm(forms.ModelForm):
             for taskkeyword in self.instance.keyword_set.all():
                 taskkeyword.delete()
             for keyword in self.cleaned_data['keywords'].split(','):
-                self.instance.keyword_set.create(name=keyword.strip(), creator=creator)
+                if len(keyword.strip()):
+                    self.instance.keyword_set.create(name=keyword.strip(), creator=creator)
 
     class Meta:
         model = Task

--- a/oneanddone/tasks/tests/test_forms.py
+++ b/oneanddone/tasks/tests/test_forms.py
@@ -62,3 +62,22 @@ class TaskFormTests(TestCase):
 
         # double-check on the keywords_list property
         eq_(task.keywords_list, 'test3, new_keyword')
+
+    def test_save_does_not_add_a_blank_keyword(self):
+        """
+        Saving the form should not add a blank keyword when
+         keywords are empty.
+        """
+        user = UserFactory.create()
+        task = TaskFactory.create()
+        data = {
+            'keywords': ' ',
+            'team': task.team.id,
+        }
+        for field in ('name', 'short_description', 'execution_time', 'difficulty',
+                      'repeatable', 'instructions', 'is_draft'):
+            data[field] = getattr(task, field)
+        form = TaskForm(instance=task, data=data)
+        form.save(user)
+
+        eq_(task.keyword_set.count(), 0)


### PR DESCRIPTION
I noticed when working on the Task Detail screen that a blank keyword was being added to tasks when no keywords were entered into the Keywords field on the Task Form. I have fixed that and added a unit test for it.

@bitgeeky r?
