### PR TITLE
Bug 1042213 - Update Task API to include attempts by users for a particu...

### DIFF
--- a/oneanddone/tasks/models.py
+++ b/oneanddone/tasks/models.py
@@ -163,8 +163,8 @@ class Task(CachedModel, CreatedModifiedModel, CreatedByModel):
 
         q_filter = q_filter & (
             pQ(repeatable=True) | (
-                ~pQ(taskattempt__state=TaskAttempt.STARTED) &
-                ~pQ(taskattempt__state=TaskAttempt.FINISHED)))
+                ~pQ(taskattempt_set__state=TaskAttempt.STARTED) &
+                ~pQ(taskattempt_set__state=TaskAttempt.FINISHED)))
 
         return q_filter
 
@@ -201,7 +201,7 @@ class TaskKeyword(CachedModel, CreatedModifiedModel, CreatedByModel):
 
 class TaskAttempt(CachedModel, CreatedModifiedModel):
     user = models.ForeignKey(User, null=True, on_delete=models.SET_NULL)
-    task = models.ForeignKey(Task)
+    task = models.ForeignKey(Task, related_name='taskattempt_set')
 
     STARTED = 0
     FINISHED = 1

--- a/oneanddone/tasks/serializers.py
+++ b/oneanddone/tasks/serializers.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from rest_framework import serializers
 
-from oneanddone.tasks.models import Task, TaskKeyword
+from oneanddone.tasks.models import Task, TaskKeyword, TaskAttempt
 
 
 class TaskKeywordSerializer(serializers.ModelSerializer):
@@ -13,16 +13,26 @@ class TaskKeywordSerializer(serializers.ModelSerializer):
         fields = ('name',)
 
 
+class TaskAttemptSerializer(serializers.ModelSerializer):
+
+    user = serializers.SlugRelatedField(many=False, slug_field='email')
+
+    class Meta:
+        model = TaskAttempt
+        fields = ('user', 'state')
+
+
 class TaskSerializer(serializers.ModelSerializer):
 
     project = serializers.SlugRelatedField(many=False, slug_field='name')
     team = serializers.SlugRelatedField(many=False, slug_field='name')
     type = serializers.SlugRelatedField(many=False, slug_field='name')
     keyword_set = TaskKeywordSerializer(required=False, many=True)
+    taskattempt_set = TaskAttemptSerializer(required=False, many=True)
 
     class Meta:
         model = Task
         fields = ('id', 'name', 'short_description', 'instructions',
                   'prerequisites', 'execution_time', 'start_date', 'end_date',
                   'is_draft', 'project', 'team', 'type', 'repeatable', 'difficulty',
-                  'why_this_matters', 'keyword_set')
+                  'why_this_matters', 'keyword_set', 'taskattempt_set')

--- a/oneanddone/tasks/tests/test_api.py
+++ b/oneanddone/tasks/tests/test_api.py
@@ -13,7 +13,7 @@ from rest_framework.authtoken.models import Token
 from nose.tools import eq_, assert_true, assert_greater
 
 from oneanddone.users.tests import UserFactory
-from oneanddone.tasks.tests import TaskFactory, TaskProjectFactory, TaskTeamFactory, TaskTypeFactory
+from oneanddone.tasks.tests import TaskFactory, TaskProjectFactory, TaskTeamFactory, TaskTypeFactory, TaskAttemptFactory
 
 
 class APITests(APITestCase):
@@ -100,13 +100,15 @@ class APITests(APITestCase):
         header = {'HTTP_AUTHORIZATION': 'Token {}'.format(self.token)}
 
         test_task = self.create_task(self.client_user)
+        task_attempt = TaskAttemptFactory.create(user=self.client_user, task=test_task)
         task_data = {"id": test_task.id, "name": test_task.name, "short_description": test_task.short_description,
                      "instructions": test_task.instructions, "prerequisites":test_task.prerequisites,
                      "execution_time": test_task.execution_time, "is_draft": test_task.is_draft, "project": test_task.project.name,
                      "team": test_task.team.name, "type": test_task.type.name, "repeatable": test_task.repeatable,
                      "start_date": test_task.start_date, "end_date": test_task.end_date, "difficulty": test_task.difficulty,
                      "why_this_matters": test_task.why_this_matters,
-                     "keyword_set": [{"name": keyword.name} for keyword in test_task.keyword_set.all()]}
+                     "keyword_set": [{"name": keyword.name} for keyword in test_task.keyword_set.all()],
+                     "taskattempt_set": [{"user":self.client_user.email, "state":task_attempt.state}]}
 
         response = self.client.get(reverse('api-task'), {}, **header)
         self.assert_response_status(response, status.HTTP_200_OK)
@@ -120,6 +122,7 @@ class APITests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
 
         test_task = self.create_task(self.client_user)
+        task_attempt = TaskAttemptFactory.create(user=self.client_user, task=test_task)
         task_uri = self.uri + str(test_task.id) + '/'
 
         task_data = {"id": test_task.id, "name": test_task.name, "short_description": test_task.short_description,
@@ -128,7 +131,8 @@ class APITests(APITestCase):
                      "team": test_task.team.name, "type": test_task.type.name, "repeatable": test_task.repeatable,
                      "start_date": test_task.start_date, "end_date": test_task.end_date, "difficulty": test_task.difficulty,
                      "why_this_matters": test_task.why_this_matters,
-                     "keyword_set": [{"name": keyword.name} for keyword in test_task.keyword_set.all()]}
+                     "keyword_set": [{"name": keyword.name} for keyword in test_task.keyword_set.all()],
+                     "taskattempt_set": [{"user":self.client_user.email, "state":task_attempt.state}]}
 
         response = self.client.get(task_uri)
         self.assert_response_status(response, status.HTTP_200_OK)
@@ -150,7 +154,8 @@ class APITests(APITestCase):
                      "team": team.name, "type": type.name, "repeatable": False,
                      "start_date": None, "end_date": None, "difficulty": 1,
                      "why_this_matters": "Task matters",
-                     "keyword_set": [{"name":"testing"},{"name":"mozwebqa"}]}
+                     "keyword_set": [{"name":"testing"},{"name":"mozwebqa"}],
+                     "taskattempt_set": [{"user":self.client_user.email, "state":0}]}
 
         response = self.client.post(self.uri, task_data, format='json')
         self.assert_response_status(response, status.HTTP_201_CREATED)


### PR DESCRIPTION
Updated the task API to include TaskAttempt values.
This supports GET and POST requests.

Also modified the unit tests for the changes made to API.

This can be tested like:

GET:

> > > requests.get('http://localhost:8000/api/v1/task/2/',headers={'Authorization':'Token 1e1d43aefd834913de3fa48c7a81a8e2287c967ff'}).text

POST:

> > > data = {"name": "Sample Task", "short_description": "Task Desc", "instructions": "Task Inst", "execution_time": 30, "is_draft": 0, "project": "Mozillians", "team": "Web QA", "type": "Automated test", "repeatable": 0, "difficulty": 1, "why_this_matters": "Task matters", "keyword_set": [{"name":"Testing"},{"name":"Webqa"}], "taskattempt_set":[{"user":"existing_user@users.com", "state":0}]}
> > > 
> > > jdata = json.dumps(data)
> > > 
> > > requests.post('http://localhost:8000/api/v1/task/',data=jdata,headers={'Content-Type': 'application/json', 'Authorization':'Token 1167810bf3c5c80897f4a443410e51431c1189c49abc'}).text
