### PR TITLE
Bug 1033475 - Allow user to configure email preferences from their profile

### DIFF
--- a/oneanddone/tasks/views.py
+++ b/oneanddone/tasks/views.py
@@ -145,7 +145,7 @@ class CreateFeedbackView(PrivacyPolicyRequiredMixin, HideNonRepeatableTaskMixin,
         template = get_template('tasks/emails/feedback_email.txt')
 
         message = template.render({
-            'feedback_user': feedback.attempt.user.email,
+            'feedback_user': feedback.attempt.user,
             'task_name': task_name,
             'task_link': task_link,
             'task_state': feedback.attempt.get_state_display(),

--- a/oneanddone/users/admin.py
+++ b/oneanddone/users/admin.py
@@ -6,6 +6,10 @@ from oneanddone.users import models
 
 
 class MyUserAdmin(UserAdmin):
+
+    list_display = ('username', 'display_email', 'is_staff', 'is_superuser',
+                    'last_login', 'date_joined')
+
     def queryset(self, request):
         """
         Only return users if they have signed the privacy policy.
@@ -15,8 +19,8 @@ class MyUserAdmin(UserAdmin):
 
 
 class UserProfileAdmin(admin.ModelAdmin):
-    list_display = ('name', 'username', 'privacy_policy_accepted')
-    readonly_fields = ('name', 'username')
+    list_display = ('name', 'username', 'privacy_policy_accepted', 'email')
+    readonly_fields = ('user', 'name', 'username', 'email')
 
     def queryset(self, request):
         """

--- a/oneanddone/users/forms.py
+++ b/oneanddone/users/forms.py
@@ -7,7 +7,11 @@ from oneanddone.users.models import UserProfile
 
 class SignUpForm(forms.ModelForm):
     pp_checkbox = forms.BooleanField(
-        label=_("You are creating a profile that will include a public username and work history. You will begin to receive email communications from Mozilla once you have completed tasks. You may unsubscribe at anytime by clicking the line at the bottom of these emails."),
+        label=_("You are creating a profile that will include a public username"
+                " and work history."
+                " You will begin to receive email communications from Mozilla"
+                " once you have completed tasks."
+                " You may configure email preferences when editing your profile."),
         required=True,
         initial=True)
     username = forms.RegexField(
@@ -30,7 +34,8 @@ class UserProfileForm(forms.ModelForm):
         label=_("Username:"),
         max_length=30, regex=r'^[a-zA-Z0-9]+$',
         error_messages={'invalid': _("This value may contain only alphanumeric characters.")})
+    consent_to_email = forms.BooleanField(required=False)
 
     class Meta:
         model = UserProfile
-        fields = ('name', 'username')
+        fields = ('name', 'username', 'consent_to_email')

--- a/oneanddone/users/migrations/0004_auto__add_field_userprofile_consent_to_email.py
+++ b/oneanddone/users/migrations/0004_auto__add_field_userprofile_consent_to_email.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'UserProfile.consent_to_email'
+        db.add_column('users_userprofile', 'consent_to_email',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'UserProfile.consent_to_email'
+        db.delete_column('users_userprofile', 'consent_to_email')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'users.userprofile': {
+            'Meta': {'object_name': 'UserProfile'},
+            'consent_to_email': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'privacy_policy_accepted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'profile'", 'unique': 'True', 'to': "orm['auth.User']"}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '30', 'unique': 'True', 'null': 'True'})
+        }
+    }
+
+    complete_apps = ['users']

--- a/oneanddone/users/models.py
+++ b/oneanddone/users/models.py
@@ -16,7 +16,7 @@ def user_unicode(self):
     """
     Change user string representation to use the user's email address.
     """
-    return u'{name} <{email}>'.format(name=self.display_name or u'Anonymous', email=self.email)
+    return u'{name} ({email})'.format(name=self.display_name or u'Anonymous', email=self.display_email)
 User.add_to_class('__unicode__', user_unicode)
 
 
@@ -31,6 +31,22 @@ def user_display_name(self):
     except UserProfile.DoesNotExist:
         return None
 User.add_to_class('display_name', user_display_name)
+
+
+@property
+def user_display_email(self):
+    """
+    If a user has not consented to receive emails
+    return 'Email consent denied'.
+    """
+    no_consent_email = 'Email consent denied'
+    try:
+        if self.profile.consent_to_email:
+            return self.email
+    except UserProfile.DoesNotExist:
+        return no_consent_email
+    return no_consent_email
+User.add_to_class('display_email', user_display_email)
 
 
 @property
@@ -57,7 +73,8 @@ User.add_to_class('attempts_requiring_notification', user_attempts_requiring_not
 class OneAndDoneUserManager(CachingManager, UserManager):
     # UserManager that prefetches user profiles when getting users.
     def get_query_set(self):
-        return super(OneAndDoneUserManager, self).get_query_set().select_related('profile')
+        return super(OneAndDoneUserManager, self).get_query_set().prefetch_related('profile')
+        # Note: changed this from select_related to prefetch_related due to https://code.djangoproject.com/ticket/15040
 User.add_to_class('objects', OneAndDoneUserManager())
 
 # Add CachingMixin to User's base classes so that it can be cached.
@@ -69,6 +86,11 @@ class UserProfile(CachedModel, models.Model):
     username = models.CharField(_lazy(u'Username'), max_length=30, unique=True, null=True)
     name = models.CharField(_lazy(u'Display Name:'), max_length=255)
     privacy_policy_accepted = models.BooleanField(default=False)
+    consent_to_email = models.BooleanField(default=True)
+
+    @property
+    def email(self):
+        return self.user.display_email
 
     def delete(self):
         self.user.delete()

--- a/oneanddone/users/templates/users/profile/edit.html
+++ b/oneanddone/users/templates/users/profile/edit.html
@@ -21,15 +21,21 @@
      https://oneanddone.mozilla.org/profile/
     {{ form.username }}
     </p>
+    {% if form.consent_to_email %}
+      <p>
+      {{ form.consent_to_email }}
+      {{ _("I'm okay with receiving occasional email from Admins") }}
+      </p>
+    {% endif %}
     {% if form.pp_checkbox %}
-    <p class="billboard content-container">
-    {{form.pp_checkbox.label}}
-    </p>
-    {{form.pp_checkbox.errors}}
-    <p>
-    {{form.pp_checkbox}}
-    {{_("* I'm okay with you handling this info as you explain in <a href='https://www.mozilla.org/en-US/privacy/websites/' target='_blank'>Mozilla's Privacy Policy</a>.")}}
-    </p>
+      <p class="billboard content-container">
+      {{form.pp_checkbox.label}}
+      </p>
+      {{form.pp_checkbox.errors}}
+      <p>
+      {{form.pp_checkbox}}
+      {{_("* I'm okay with you handling this info as you explain in <a href='https://www.mozilla.org/en-US/privacy/websites/' target='_blank'>Mozilla's Privacy Policy</a>.")}}
+      </p>
     {% endif %}
     <div class="actions-container">
     {% if action == 'Update' %}

--- a/oneanddone/users/tests/test_models.py
+++ b/oneanddone/users/tests/test_models.py
@@ -16,14 +16,14 @@ class UserTests(TestCase):
         email address.
         """
         user = UserProfileFactory.create(name='Foo Bar', user__email='foo@example.com').user
-        eq_(unicode(user), u'Foo Bar <foo@example.com>')
+        eq_(unicode(user), u'Foo Bar (foo@example.com)')
 
     def test_unicode_no_name(self):
         """
-        If a user has no display name, use "Anonymous" in its place.
+        If a user has no profile, use "Anonymous" in its place and hide the email address.
         """
         user = UserFactory.build(email='foo@example.com')
-        eq_(unicode(user), u'Anonymous <foo@example.com>')
+        eq_(unicode(user), u'Anonymous (Email consent denied)')
 
     def test_display_name(self):
         """
@@ -39,6 +39,54 @@ class UserTests(TestCase):
         """
         user = UserFactory.build()
         eq_(user.display_name, None)
+
+    def test_display_email_with_consent(self):
+        """
+        The display_email attribute should return the user's email
+        if they have granted consent.
+        """
+        user = UserProfileFactory.create(
+            consent_to_email=True,
+            user__email='foo@example.com').user
+        eq_(user.display_email, 'foo@example.com')
+
+    def test_display_email_without_consent(self):
+        """
+        The display_email attribute should return 'Email consent denied'
+        if they have denied consent.
+        """
+        user = UserProfileFactory.create(
+            consent_to_email=False,
+            user__email='foo@example.com').user
+        eq_(user.display_email, 'Email consent denied')
+
+    def test_display_email_without_profile(self):
+        """
+        The display_email attribute should return 'Email consent denied'
+        if they have no profile.
+        """
+        user = UserFactory.build(email='foo@example.com')
+        eq_(user.display_email, 'Email consent denied')
+
+    def test_profile_email_with_consent(self):
+        """
+        The email attribute should return the user's email
+        if they have granted consent.
+        """
+        profile = UserProfileFactory.create(
+            consent_to_email=True,
+            user__email='foo@example.com')
+        eq_(profile.email, 'foo@example.com')
+
+    def test_profile_email_without_consent(self):
+        """
+        The email attribute should return 'Email consent denied'
+        if they have denied consent.
+        """
+        profile = UserProfileFactory.create(
+            consent_to_email=False,
+            user__email='foo@example.com')
+        eq_(profile.email, 'Email consent denied')
 
     def test_attempts_finished_count(self):
         user = UserFactory.create()


### PR DESCRIPTION
Update User Profile edit screen to allow email preference
Update text on account creation screen to indicate how to remove consent to email
Don't send email address in feedback email if they have not consented
Hide user email from most admin screens if they have not consented to receive email
Add consent_to_email field to UserProfile
Change OneAndDoneUserManager.get_query_set() to from select_related to prefetch_related due to https://code.djangoproject.com/ticket/15040

Should secure Auth - User admin to superusers only so that not everyone can see all the email addresses
