### PR TITLE
Fix problem where a task attempt was trying to be retrieved for a non logged-in user

### DIFF
--- a/oneanddone/tasks/mixins.py
+++ b/oneanddone/tasks/mixins.py
@@ -3,8 +3,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
+from django.shortcuts import get_object_or_404
 
-from oneanddone.tasks.models import Task
+from oneanddone.tasks.models import Task, TaskAttempt
 
 
 class TaskMustBeAvailableMixin(object):
@@ -28,6 +29,17 @@ class HideNonRepeatableTaskMixin(object):
         if not task.is_available_to_user(self.request.user):
             raise Http404('Task unavailable.')
         return task
+
+
+class GetUserAttemptMixin(object):
+    """
+    Retrieve a user attempt and add it to the view's self scope
+    for later use.
+    """
+    def dispatch(self, request, *args, **kwargs):
+        self.attempt = get_object_or_404(TaskAttempt, pk=kwargs['pk'], user=request.user,
+                                         state__in=[TaskAttempt.FINISHED, TaskAttempt.ABANDONED])
+        return super(GetUserAttemptMixin, self).dispatch(request, *args, **kwargs)
 
 
 class APIRecordCreatorMixin(object):

--- a/oneanddone/tasks/tests/test_views.py
+++ b/oneanddone/tasks/tests/test_views.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from django.core.urlresolvers import reverse
-from django.http import Http404
 
 from mock import Mock, patch
 from nose.tools import eq_, ok_
@@ -147,30 +146,6 @@ class StartTaskViewTests(TestCase):
             redirect.assert_called_with(self.task)
             ok_(TaskAttempt.objects.filter(user=user, task=self.task, state=TaskAttempt.STARTED)
                 .exists())
-
-
-class CreateFeedbackViewTests(TestCase):
-    def setUp(self):
-        self.view = views.CreateFeedbackView()
-
-    def test_missing_attempt_404(self):
-        """
-        If there is no task attempt with the given ID, return a 404.
-        """
-        request = Mock(user=UserFactory.create())
-        with self.assertRaises(Http404):
-            self.view.dispatch(request, pk=9999)
-
-    def test_feedback_not_your_attempt(self):
-        """
-        If the current user doesn't match the user for the requested
-        task attempt, return a 404.
-        """
-        attempt = TaskAttemptFactory.create()
-        request = Mock(user=UserFactory.create())
-
-        with self.assertRaises(Http404):
-            self.view.dispatch(request, pk=attempt.pk)
 
 
 class RandomTasksViewTests(TestCase):


### PR DESCRIPTION
This scenario was generating exceptions which I was seeing via email. The problem was that the mixin that was supposed to redirect a user when `CreateFeedbackView` was called was not firing before the attempt to retrieve the attempt. I have fixed that by making the code that retrieves the attempt a mixin as well.

The stack trace of the exception is:

```
Traceback (most recent call last):

  File "/app/app/vendor/lib/python/django/core/handlers/base.py", line 111, in get_response
    response = callback(request, *callback_args, **callback_kwargs)

  File "/opt/ActivePython-2.7/lib/python2.7/site-packages/newrelic-1.11.0.55/newrelic/api/object_wrapper.py", line 216, in __call__
    self._nr_instance, args, kwargs)

  File "/opt/ActivePython-2.7/lib/python2.7/site-packages/newrelic-1.11.0.55/newrelic/hooks/framework_django.py", line 475, in wrapper
    return wrapped(*args, **kwargs)

  File "/app/app/vendor/lib/python/django/views/generic/base.py", line 48, in view
    return self.dispatch(request, *args, **kwargs)

  File "/app/app/oneanddone/tasks/views.py", line 123, in dispatch
    state__in=[TaskAttempt.FINISHED, TaskAttempt.ABANDONED])

  File "/app/app/vendor/lib/python/django/shortcuts/__init__.py", line 113, in get_object_or_404
    return queryset.get(*args, **kwargs)

  File "/app/app/vendor/lib/python/django/db/models/query.py", line 358, in get
    clone = self.filter(*args, **kwargs)

  File "/app/app/vendor/lib/python/django/db/models/query.py", line 624, in filter
    return self._filter_or_exclude(False, *args, **kwargs)

  File "/app/app/vendor/lib/python/django/db/models/query.py", line 642, in _filter_or_exclude
    clone.query.add_q(Q(*args, **kwargs))

  File "/app/app/vendor/lib/python/django/db/models/sql/query.py", line 1250, in add_q
    can_reuse=used_aliases, force_having=force_having)

  File "/app/app/vendor/lib/python/django/db/models/sql/query.py", line 1185, in add_filter
    connector)

  File "/app/app/vendor/lib/python/django/db/models/sql/where.py", line 69, in add
    value = obj.prepare(lookup_type, value)

  File "/app/app/vendor/lib/python/django/db/models/sql/where.py", line 320, in prepare
    return self.field.get_prep_lookup(lookup_type, value)

  File "/app/app/vendor/lib/python/django/db/models/fields/related.py", line 137, in get_prep_lookup
    return self._pk_trace(value, 'get_prep_lookup', lookup_type)

  File "/app/app/vendor/lib/python/django/db/models/fields/related.py", line 210, in _pk_trace
    v = getattr(field, prep_func)(lookup_type, v, **kwargs)

  File "/app/app/vendor/lib/python/django/db/models/fields/__init__.py", line 310, in get_prep_lookup
    return self.get_prep_value(value)

  File "/app/app/vendor/lib/python/django/db/models/fields/__init__.py", line 537, in get_prep_value
    return int(value)

TypeError: int() argument must be a string or a number, not 'SimpleLazyObject'
```
