### PR TITLE
Bug 1030972 - Import tasks from Bugzilla

### DIFF
--- a/oneanddone/tasks/admin.py
+++ b/oneanddone/tasks/admin.py
@@ -1,7 +1,6 @@
 from django.contrib import admin
 
 from oneanddone.tasks import models
-from oneanddone.tasks.forms import TaskModelForm
 
 
 class RecordCreatorMixin(object):

--- a/oneanddone/tasks/forms.py
+++ b/oneanddone/tasks/forms.py
@@ -8,7 +8,7 @@ from requests.exceptions import RequestException
 from tower import ugettext as _
 from urlparse import urlparse, parse_qs
 
-from oneanddone.base.widgets import CalendarInput, HorizRadioSelect
+from oneanddone.base.widgets import CalendarInput
 from oneanddone.tasks.bugzilla_utils import BugzillaUtils
 from oneanddone.tasks.models import (BugzillaBug, Feedback, Task,
                                      TaskImportBatch,
@@ -37,8 +37,8 @@ class PreviewConfirmationForm(forms.Form):
 
 
 class TaskInvalidationCriterionForm(forms.Form):
-    criterion = forms.ModelChoiceField(queryset=
-                                       TaskInvalidationCriterion.objects.all())
+    criterion = forms.ModelChoiceField(
+        queryset=TaskInvalidationCriterion.objects.all())
 
 
 class BaseTaskInvalidCriteriaFormSet(forms.formsets.BaseFormSet):
@@ -125,8 +125,7 @@ class TaskImportBatchForm(forms.ModelForm):
         fields = ('description', 'query')
         widgets = {
             'query': forms.TextInput(attrs={'size': 100, 'class': 'fill-width'}),
-            'description': forms.TextInput(attrs={'size': 100, 'class': 'fill-width'})
-            }
+            'description': forms.TextInput(attrs={'size': 100, 'class': 'fill-width'})}
 
 
 class TaskForm(forms.ModelForm):
@@ -141,7 +140,6 @@ class TaskForm(forms.ModelForm):
             initial['keywords'] = kwargs['instance'].keywords_list
             kwargs['initial'] = initial
         super(TaskForm, self).__init__(*args, **kwargs)
-        # self.fields['keywords'].value = self.instance.keywords_list
 
     def save(self, creator, *args, **kwargs):
         self.instance.creator = creator
@@ -186,21 +184,3 @@ class TaskForm(forms.ModelForm):
         css = {
             'all': ('css/admin_ace.css',)
         }
-
-
-class TaskModelForm(forms.ModelForm):
-    instructions = (forms.CharField(widget=AceWidget(mode='markdown',
-                    theme='textmate', width='800px', height='600px',
-                    wordwrap=True)))
-
-    class Meta:
-        model = Task
-
-    class Media:
-        css = {
-            'all': ('css/admin_ace.css',)
-        }
-
-    instructions.help_text = ('Instructions are written in '
-                              '<a href="http://markdowntutorial.com/" '
-                              'target="_blank">Markdown</a>.')

--- a/oneanddone/tasks/helpers.py
+++ b/oneanddone/tasks/helpers.py
@@ -1,4 +1,10 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import re
+
 from jingo import register
+from jinja2 import Markup
 
 
 @register.function
@@ -6,3 +12,13 @@ def page_url(request, page):
     query = request.GET.copy()
     query['page'] = page
     return ''.join(['?', query.urlencode()])
+
+
+@register.filter
+def buglinkify(obj):
+    return Markup(
+        re.sub(
+            r'([Bb]ug (\d+))',
+            r'<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=\2">\1</a>',
+            unicode(obj))
+    )

--- a/oneanddone/tasks/models.py
+++ b/oneanddone/tasks/models.py
@@ -6,8 +6,8 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import Q
@@ -226,14 +226,14 @@ class Task(CachedModel, CreatedModifiedModel, CreatedByModel):
     @property
     def is_taken(self):
         return (not self.repeatable and
-                self.taskattempt_set.filter(state=
-                                            TaskAttempt.STARTED).exists())
+                self.taskattempt_set.filter(
+                    state=TaskAttempt.STARTED).exists())
 
     @property
     def is_completed(self):
         return (not self.repeatable and
-                self.taskattempt_set.filter(state=
-                                            TaskAttempt.FINISHED).exists())
+                self.taskattempt_set.filter(
+                    state=TaskAttempt.FINISHED).exists())
 
     @property
     def instructions_html(self):

--- a/oneanddone/tasks/templates/tasks/confirmation.html
+++ b/oneanddone/tasks/templates/tasks/confirmation.html
@@ -32,8 +32,14 @@
   <h2>{{ _('Tasks to Import') }}</h2>
   <ul>
   {% for bug in bugs %}
-    <li><em>{{ basename }} <a href="{{ bugzilla_url }}{{ bug['id'] }}">Bug {{ bug['id'] }}</a></em>
-    <div>"{{ bug['summary'] }}"</div></li>
+    <li>
+      <em>
+        {% filter buglinkify %}
+          {{ basename }} Bug {{ bug['id'] }}
+        {% endfilter %}
+      </em>
+      <div>"{{ bug['summary'] }}"</div>
+    </li>
   {% endfor %}
   </ul>
 

--- a/oneanddone/tasks/templates/tasks/detail.html
+++ b/oneanddone/tasks/templates/tasks/detail.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 <main class="billboard content-container task-detail">
-  <h1>{{ task.name }}</h1>
+  <h1>{{ task.name|buglinkify }}</h1>
   <div class="row">
     <div>{{ task.short_description }}</div>
   </div>

--- a/oneanddone/tasks/tests/test_helpers.py
+++ b/oneanddone/tasks/tests/test_helpers.py
@@ -8,7 +8,7 @@ from mock import Mock
 from nose.tools import eq_
 
 from oneanddone.base.tests import TestCase
-from oneanddone.tasks.helpers import page_url
+from oneanddone.tasks.helpers import page_url, buglinkify
 
 
 class PageUrlTests(TestCase):
@@ -45,3 +45,41 @@ class PageUrlTests(TestCase):
         eq_(args, {'foo': ['bar', 'ok'], 'baz': ['5'], 'page': ['4']})
 
 
+class BuglinkifyTests(TestCase):
+
+    def setUp(self):
+        self.bugzilla_url_prefix = 'https://bugzilla.mozilla.org/show_bug.cgi?id='
+
+    def test_with_bug_ucase(self):
+        """
+        buglinkify should linkify a capitalized bug in a string.
+        """
+        name = 'Test this string with Bug 12345'
+        eq_(buglinkify(name),
+            'Test this string with <a href="%s12345">Bug 12345</a>' %
+            self.bugzilla_url_prefix)
+
+    def test_with_bug_lcase(self):
+        """
+        buglinkify should linkify a lowercase bug in a string.
+        """
+        name = 'Test this string with bug 12345'
+        eq_(buglinkify(name),
+            'Test this string with <a href="%s12345">bug 12345</a>' %
+            self.bugzilla_url_prefix)
+
+    def test_without_bug(self):
+        """
+        buglinkify should leave string intact without a bug.
+        """
+        name = 'Test this string with boog 12345'
+        eq_(buglinkify(name), name)
+
+    def test_with_extra_numbers(self):
+        """
+        buglinkify should only linkify the bug.
+        """
+        name = 'Test this 12345 string with Bug 12345 and 12345'
+        eq_(buglinkify(name),
+            'Test this 12345 string with <a href="%s12345">Bug 12345</a> and 12345' %
+            self.bugzilla_url_prefix)

--- a/oneanddone/tasks/tests/test_views.py
+++ b/oneanddone/tasks/tests/test_views.py
@@ -17,15 +17,16 @@ from oneanddone.users.tests import UserFactory
 class TaskDetailViewTests(TestCase):
     def setUp(self):
         self.view = views.TaskDetailView()
+        self.view.request = Mock()
+        self.view.object = Mock()
+        self.view.object.name = 'name'
 
     def test_get_context_data_not_authenticated(self):
         """
         If the current user isn't authenticated, don't include an
         attempt in the context.
         """
-        self.view.request = Mock()
         self.view.request.user.is_authenticated.return_value = False
-        self.view.object = Mock()
 
         with patch('oneanddone.tasks.views.generic.DetailView.get_context_data') as get_context_data:
             get_context_data.return_value = {}
@@ -37,9 +38,7 @@ class TaskDetailViewTests(TestCase):
         If the current user is authenticated, fetch their attempt for
         the current task using get_object_or_none.
         """
-        self.view.request = Mock()
         self.view.request.user.is_authenticated.return_value = True
-        self.view.object = Mock()
 
         get_object_patch = patch('oneanddone.tasks.views.get_object_or_none')
         context_patch = patch('oneanddone.tasks.views.generic.DetailView.get_context_data')
@@ -55,9 +54,7 @@ class TaskDetailViewTests(TestCase):
         """
         If the task is taken, correct values should be added to the context.
         """
-        self.view.request = Mock()
         self.view.request.user.is_authenticated.return_value = False
-        self.view.object = Mock()
         self.view.object.is_taken = True
 
         with patch('oneanddone.tasks.views.generic.DetailView.get_context_data') as get_context_data:
@@ -70,9 +67,7 @@ class TaskDetailViewTests(TestCase):
         """
         If the task is taken, correct values should be added to the context.
         """
-        self.view.request = Mock()
         self.view.request.user.is_authenticated.return_value = False
-        self.view.object = Mock()
         self.view.object.is_taken = False
         self.view.object.is_completed = True
 
@@ -86,9 +81,7 @@ class TaskDetailViewTests(TestCase):
         """
         If the task is taken, correct values should be added to the context.
         """
-        self.view.request = Mock()
         self.view.request.user.is_authenticated.return_value = False
-        self.view.object = Mock()
         self.view.object.is_taken = False
         self.view.object.is_completed = False
 

--- a/oneanddone/tasks/views.py
+++ b/oneanddone/tasks/views.py
@@ -1,6 +1,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import re
+
 from django.contrib import messages
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
@@ -24,8 +26,7 @@ from oneanddone.tasks.mixins import (APIRecordCreatorMixin,
 from oneanddone.tasks.mixins import (TaskMustBeAvailableMixin,
                                      HideNonRepeatableTaskMixin)
 from oneanddone.tasks.mixins import GetUserAttemptMixin
-from oneanddone.tasks.models import (BugzillaBug, Feedback, Task, TaskAttempt,
-                                     TaskInvalidationCriterion)
+from oneanddone.tasks.models import BugzillaBug, Feedback, Task, TaskAttempt
 from oneanddone.tasks.serializers import TaskSerializer
 from oneanddone.users.mixins import (MyStaffUserRequiredMixin,
                                      PrivacyPolicyRequiredMixin)
@@ -242,6 +243,7 @@ class ImportTasksView(LoginRequiredMixin, MyStaffUserRequiredMixin, generic.Temp
         ctx = super(ImportTasksView, self).get_context_data(**kwargs)
         ctx.update(kwargs)
         ctx['action'] = 'Import'
+        ctx['import_obj'] = 'tasks'
         ctx['cancel_url'] = reverse('tasks.list')
         return ctx
 
@@ -255,7 +257,6 @@ class ImportTasksView(LoginRequiredMixin, MyStaffUserRequiredMixin, generic.Temp
             ctx['basename'] = forms['task_form'].cleaned_data['name']
             ctx['bugs'] = bugs
             ctx['num_tasks'] = len(bugs)
-            ctx['bugzilla_url'] = 'https://bugzilla.mozilla.org/show_bug.cgi?id='
             return self.render_to_response(self.get_context_data(**ctx))
 
     def forms_invalid(self, forms):


### PR DESCRIPTION
This is a post-merge cleanup of some of the code (pep8 stuff) and also addresses two issues:
1. The label for "Import task" has been changed to "Import tasks"
2. On the task detail page, if a Bug id exists in the task name it becomes linkified

Note that I am not sure of my solution to #2. I'm not sure if I should have put the code into the view, and also not sure of my use of `|safe` in the template, so I'd appreciate feedback on those.
