### PR TITLE
Adjusted installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ you don't have `pip` installed, you can install it with `easy_install pip`.
    `oneanddone/settings/local.py` and customizing the settings in it:
 
    ```sh
+   $ cd ..
    $ cp oneanddone/settings/local.py-dist oneanddone/settings/local.py
    ```
 


### PR DESCRIPTION
The way that requirements/compiled.txt calls on the vendor requirements expects the call to come from the requirements directory level.
