### PR TITLE
Bug 1096435 - Clone task data is permanently saved under /create

### DIFF
--- a/oneanddone/tasks/tests/test_views.py
+++ b/oneanddone/tasks/tests/test_views.py
@@ -37,24 +37,27 @@ class CreateTaskViewTests(TestCase):
         """
         user = UserFactory.create()
         self.view.request = Mock(user=user)
+        self.view.kwargs = {}
         with patch('oneanddone.tasks.views.generic.CreateView.get_form_kwargs') as get_form_kwargs:
             get_form_kwargs.return_value = {'initial': {}}
             kwargs = self.view.get_form_kwargs()
         eq_(kwargs['initial']['owner'], user)
 
-    def test_get_initial_populates_form_with_data_to_be_cloned(self):
+    def test_get_form_kwargs_populates_form_with_data_to_be_cloned(self):
         """
         When accessed via the tasks.clone url, the view displays a form
         whose initial data is that of the task being cloned, except for
         the 'name' field, which should be prefixed with 'Copy of '
         """
+        user = UserFactory.create()
         original_task = TaskFactory.create()
         TaskKeywordFactory.create_batch(3, task=original_task)
         original_data = get_filled_taskform(original_task).data
-        self.view.kwargs = {'clone': original_task.pk }
-        with patch('oneanddone.tasks.views.generic.CreateView.get_initial') as get_initial:
-            get_initial.return_value = {}
-            initial = self.view.get_initial()
+        self.view.kwargs = {'clone': original_task.pk}
+        self.view.request = Mock(user=user)
+        with patch('oneanddone.tasks.views.generic.CreateView.get_form_kwargs') as get_form_kwargs:
+            get_form_kwargs.return_value = {'initial': {}}
+            initial = self.view.get_form_kwargs()['initial']
         eq_(initial['keywords'], original_task.keywords_list)
         eq_(initial['name'], ' '.join(['Copy of', original_task.name]))
         del original_data['name']

--- a/oneanddone/tasks/views.py
+++ b/oneanddone/tasks/views.py
@@ -124,15 +124,12 @@ class CreateTaskView(LoginRequiredMixin, MyStaffUserRequiredMixin, generic.Creat
     def get_form_kwargs(self):
         kwargs = super(CreateTaskView, self).get_form_kwargs()
         kwargs['initial']['owner'] = self.request.user
-        return kwargs
-
-    def get_initial(self):
         if self.kwargs.get('clone'):
             original_task = Task.objects.get(pk=self.kwargs['clone'])
-            self.initial.update(model_to_dict(original_task))
-            self.initial['keywords'] = original_task.keywords_list
-            self.initial['name'] = ' '.join(['Copy of', original_task.name])
-        return self.initial
+            kwargs['initial'].update(model_to_dict(original_task))
+            kwargs['initial']['keywords'] = original_task.keywords_list
+            kwargs['initial']['name'] = ' '.join(['Copy of', original_task.name])
+        return kwargs
 
     def get_context_data(self, *args, **kwargs):
         ctx = super(CreateTaskView, self).get_context_data(*args, **kwargs)


### PR DESCRIPTION
Fix code to not set view.initial but rather to return the proper kwargs for the form

This bug actually manifested in a number of ways, and this fixes all of them.
