### PR TITLE
Bug 1105491 - Users should not be able to make task it's own next task

### DIFF
--- a/oneanddone/tasks/forms.py
+++ b/oneanddone/tasks/forms.py
@@ -60,6 +60,9 @@ class TaskForm(forms.ModelForm):
             initial = kwargs.get('initial', {})
             initial['keywords'] = kwargs['instance'].keywords_list
             kwargs['initial'] = initial
+            task_id = kwargs.pop('task_id', None)
+            if task_id:
+                self.base_fields['next_task'].queryset = self.base_fields['next_task'].queryset.exclude(id=task_id)
         super(TaskForm, self).__init__(*args, **kwargs)
 
     def _process_keywords(self, creator):

--- a/oneanddone/tasks/views.py
+++ b/oneanddone/tasks/views.py
@@ -371,6 +371,10 @@ class UpdateTaskView(LoginRequiredMixin, MyStaffUserRequiredMixin, generic.Updat
     form_class = TaskForm
     template_name = 'tasks/form.html'
 
+    def get_form(self, form_class):
+        """ Override get_form to pass task_id to the constructor."""
+        return form_class(task_id=self.get_object().id, **self.get_form_kwargs())
+
     def get_context_data(self, *args, **kwargs):
         ctx = super(UpdateTaskView, self).get_context_data(*args, **kwargs)
         ctx['task_form'] = ctx.get('form')


### PR DESCRIPTION
Fix the Task Update form so that the current task does not appear in the "Next Task" dropdown

@glogiotatidis r?  I'm really not sure if this is the best way to do this. It seems a bit complex, but I couldn't think of a simpler way of giving the queryset access to the current task object.