### PR TITLE
Edited homepage intro to remove QA references

### DIFF
--- a/oneanddone/base/templates/base/home.html
+++ b/oneanddone/base/templates/base/home.html
@@ -7,7 +7,7 @@
 
 {% block content %}
   <section class="home-header">
-    <h4>{{ _('Contribute to Mozilla QA - One task at a time, One day at a time.') }}</h4>
+    <h4>{{ _('Contribute to Mozilla - One task at a time, One day at a time.') }}</h4>
     <p>
       {% trans ao_href = 'https://oneanddone.mozilla.org/en-US/?search=&project=7',
          os_href = 'https://oneanddone.mozilla.org/en-US/?search=&team=4', 
@@ -21,12 +21,12 @@
            One and Done gives users a wide variety of ways to contribute to Mozilla.
            You can pick an easy task that only takes a few minutes &#45; or take on a bigger
            challenge. This includes working on manual testing, automation, bug verification,
-           mobile testing and more. Tasks are from all QA teams &#45; so you can get involved
+           mobile testing and more. Tasks are from a variety of Mozilla teams &#45; so you can get involved
            with <a href= "{{ ao_href }}"> Automation</a>, <a href="{{ os_href }}"> Firefox OS</a>,
            <a href="{{ ds_href }}">  Desktop Firefox </a> (<a href= "{{ ni_href}}"> Nightly</a>,
            <a href= "{{ au_href }}"> Aurora</a>, and <a href= "{{ be_href }}"> Beta</a> ) ,
            <a href= "{{ mw_href }}"> Mozilla websites</a>, <a href= "{{ se_href }}">Services</a>, 
-           or <a href= "{{ th_href }}">Thunderbird</a>.
+           <a href= "{{ th_href }}">Thunderbird</a> or more.
       {% endtrans %}
    </p>
   <p>


### PR DESCRIPTION
Remove references to "QA" on the homepage intro box, for bug 1145286.