### PR TITLE
Use django-maintenancemode to enable maintenance mode

### DIFF
--- a/oneanddone/base/templates/503.html
+++ b/oneanddone/base/templates/503.html
@@ -1,0 +1,13 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+{% extends 'base/base.html' %}
+
+{% set title = _('Maintenance Mode') %}
+
+{% block content %}
+  <main class="billboard content-container">
+    <h2>{{ _('Sorry, One and Done is currently unavailable due to site maintenance.') }}</h2>
+    <p>{{ _('Please try again later.') }}</p>
+  </main>
+{% endblock %}

--- a/oneanddone/base/templates/base/base.html
+++ b/oneanddone/base/templates/base/base.html
@@ -38,7 +38,8 @@
       <div id="wrapper">
         <header id="masthead">
           <a href="http://www.mozilla.org/" id="tabzilla">Mozilla</a>
-          <nav id="nav-main" role="menubar" class="drop-down">
+          {% if not settings.MAINTENANCE_MODE %}
+            <nav id="nav-main" role="menubar" class="drop-down">
             <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{ _('Menu') }}</span>
             <ul role="menu" id="nav-main-menu">
               <li role="menuitem">
@@ -80,6 +81,7 @@
               </li>
             </ul>
           </nav>
+          {% endif %}
           <h2>
             <a href="{{ url('base.home') }}" id="logo-container" title="{{ _('Home') }}">
               <img src="{{ static('img/qa-logo-header.png') }}" width="45" height="45" alt="{{ _('Mozilla QA logo') }}" class="logo">

--- a/oneanddone/settings/base.py
+++ b/oneanddone/settings/base.py
@@ -54,6 +54,7 @@ INSTALLED_APPS = [
     'django_browserid',
     'django_nose',
     'jingo_minify',
+    'maintenancemode',
     'product_details',
     'rest_framework',
     'rest_framework.authtoken',
@@ -70,6 +71,7 @@ MIDDLEWARE_CLASSES = (
     'session_csrf.CsrfMiddleware',  # Must be after auth middleware.
     'django.contrib.messages.middleware.MessageMiddleware',
     'commonware.middleware.FrameOptionsHeader',
+    'maintenancemode.middleware.MaintenanceModeMiddleware',
     'oneanddone.base.middleware.TimezoneMiddleware',
     'oneanddone.base.middleware.ClosedTaskNotificationMiddleware',
 )
@@ -134,6 +136,8 @@ DEV = config('DEV', default=DEBUG, cast=bool)
 TEMPLATE_DEBUG = config('DEBUG', default=DEBUG, cast=bool)
 
 ALLOWED_HOSTS = config('ALLOWED_HOSTS', default='*', cast=Csv())
+
+MAINTENANCE_MODE = config('DJANGO_MAINTENANCE_MODE', default=False, cast=bool)
 
 ROOT_URLCONF = 'oneanddone.urls'
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -149,6 +149,13 @@ mock==1.0.1
 # sha256: A3VLx7JWOXwbZG5QSOIpFZD1CAFxrbiwD04tc4THbu4
 GitPython==0.1.7
 
+# sha256: h50rRJXBxArSTD_WVGnDcveqtQz3ogbH1yOSiJCCMGg
+django-maintenancemode==0.11.0
+
+# sha256: uhN1-xAk6OkVR1BNQ5IyF5XJif3lALluvHyTiE94bmA
+# sha256: PZvJY9gAiuFR1sZk-f1VRCcF6puebXznfN1Av5LZHzo
+django-appconf==1.0.1
+
 # Requirements tied to specific commits
 # sha256: 1rhJV1lByVPZ-yeMIc8aLkpmilR1XeBa0DUAiHGrt1c
 https://github.com/jsocol/jingo-minify/archive/2beb546949ed2cb4eb866bab6dd643047d803a95.zip#egg=jingo-minify

--- a/stackato.yml
+++ b/stackato.yml
@@ -23,6 +23,7 @@ env:
   GOOGLE_ANALYTICS_ID: ''
   EMAIL_HOST: ''
   SERVER_EMAIL: ''
+  MAINTENANCE_MODE: false
 min_version:
   client: 1.4.5
 services:


### PR DESCRIPTION
This uses `django-maintenancemode` to allow us to put the app into maintenance mode. This is needed to we can take a database backup and then restore to Heroku and wait for DNS to propagate.