### PR TITLE
Fix two problems with feedback

### DIFF
--- a/oneanddone/tasks/mixins.py
+++ b/oneanddone/tasks/mixins.py
@@ -20,15 +20,18 @@ class APIRecordCreatorMixin(object):
         obj.creator = self.request.user
 
 
-class GetUserAttemptMixin(object):
+class GetUserAttemptForFeedbackMixin(object):
     """
     Retrieve a user attempt and add it to the view's self scope
     for later use.
     """
     def dispatch(self, request, *args, **kwargs):
-        self.attempt = get_object_or_404(TaskAttempt, pk=kwargs['pk'], user=request.user,
-                                         state__in=[TaskAttempt.FINISHED, TaskAttempt.ABANDONED])
-        return super(GetUserAttemptMixin, self).dispatch(request, *args, **kwargs)
+        self.attempt = get_object_or_404(TaskAttempt,
+                                         pk=kwargs['pk'],
+                                         user=request.user,
+                                         state__in=[TaskAttempt.FINISHED, TaskAttempt.ABANDONED],
+                                         feedback__isnull=True)
+        return super(GetUserAttemptForFeedbackMixin, self).dispatch(request, *args, **kwargs)
 
 
 class HideNonRepeatableTaskMixin(object):

--- a/oneanddone/tasks/views.py
+++ b/oneanddone/tasks/views.py
@@ -25,7 +25,7 @@ from oneanddone.tasks.forms import (FeedbackForm, SubmitVerifiedTaskForm,
 from oneanddone.tasks.mixins import (APIOnlyCreatorMayDeleteMixin,
                                      APIRecordCreatorMixin,
                                      BaseURLMixin,
-                                     GetUserAttemptMixin,
+                                     GetUserAttemptForFeedbackMixin,
                                      HideNonRepeatableTaskMixin,
                                      TaskMustBeAvailableMixin)
 from oneanddone.tasks.models import (BugzillaBug, Feedback, Task, TaskAttempt,
@@ -76,7 +76,9 @@ class AvailableTasksView(TaskMustBeAvailableMixin, FilterView):
 
 
 class CreateFeedbackView(LoginRequiredMixin,
-                         HideNonRepeatableTaskMixin, GetUserAttemptMixin,
+                         HideNonRepeatableTaskMixin,
+                         GetUserAttemptForFeedbackMixin,
+                         BaseURLMixin,
                          generic.CreateView):
     model = Feedback
     form_class = FeedbackForm


### PR DESCRIPTION
- BaseURLMixin was removed accidentally from CreateFeedbackView
- Users should not be allowed to re-access the feedback url for an attempt after feedback has been given once