### PR TITLE
Allow for functional tests to be run against deployed environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ env:
 install:
   - "pip install -r requirements.txt"
   - "pip install -r requirements/test.txt"
+  - "pip install -r requirements/test-local.txt"
   - "npm install"
   - "psql -c 'create database oneanddone;' -U postgres"
 
@@ -50,7 +51,7 @@ script:
   - "python -m smtpd -n -c DebuggingServer localhost:1025 &"
   - "flake8 ."
   - "python manage.py test oneanddone/tasks/ oneanddone/users/"
-  - "py.test -v -s --driver Firefox --html results/results.html oneanddone/tests/functional/"
+  - "py.test -v -s --driver Firefox --html results/results.html --reuse-db oneanddone/tests/functional/"
 
 notifications:
     irc:

--- a/oneanddone/tests/functional/conftest.py
+++ b/oneanddone/tests/functional/conftest.py
@@ -50,12 +50,24 @@ def new_user(persona_test_user):
 
 
 @pytest.fixture(scope='session')
-def base_url(base_url, live_server):
-    return base_url or live_server.url
+def base_url(base_url, request):
+    return base_url or request.getfuncargvalue("live_server").url
 
 
 @pytest.fixture(scope='function')
-def task(base_url, transactional_db):
-    if '127.0.0.1' in base_url or 'localhost' in base_url:
+def is_local(base_url):
+    return '127.0.0.1' in base_url or 'localhost' in base_url
+
+
+@pytest.fixture(scope='function', autouse=True)
+def use_transactional_db(base_url, is_local, request):
+    if is_local:
+        # if we are running locally we need the transactional_db fixture
+        request.getfuncargvalue("transactional_db")
+
+
+@pytest.fixture(scope='function')
+def task(base_url, is_local):
+    if is_local:
         from oneanddone.tasks.tests import TaskFactory
         return TaskFactory.create()

--- a/requirements/test-local.txt
+++ b/requirements/test-local.txt
@@ -1,0 +1,3 @@
+# We need to use a commit of mine which re-enables static asset serving with the live_server
+# See https://github.com/pytest-dev/pytest-django/issues/294
+-e git+https://github.com/bobsilverberg/pytest-django.git@6d8d45c4fd1eb58b553045dd844e35885fcf67e6#egg=pytest_django

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,5 @@
 bidpom
+pytest==2.8.5
 pytest-selenium
+pytest-xdist==1.13.1
 requests==2.8.1
-# We need to use a commit of mine which re-enables static asset serving with the live_server
-# See https://github.com/pytest-dev/pytest-django/issues/294
--e git+https://github.com/bobsilverberg/pytest-django.git@6d8d45c4fd1eb58b553045dd844e35885fcf67e6#egg=pytest_django

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,4 @@ exclude=bin,docs,migrations
 
 [pytest]
 DJANGO_SETTINGS_MODULE=oneanddone.settings
-addopts=--reuse-db
 sensitive_url=mozilla\.org


### PR DESCRIPTION
Split out dependencies that are only needed for testing with a local host
Remove --reuse-db from setup.cfg
Make use of pytest-django fixtures conditional on tests running locally