### PR TITLE
Update pytest to 2.9.1

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
 bidpom
 pypom
-pytest==2.9.0
+pytest==2.9.1
 pytest-selenium
 pytest-xdist==1.14
 requests==2.9.1


### PR DESCRIPTION
Some nice fixes in 2.9.1 - we've upgraded all Web QA projects already, as well.

pytest.org/latest/changelog.html