### PR TITLE
pin firefox version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ python:
     - 2.7
 
 addons:
-  firefox: latest
+  firefox: "46.0.1"
   artifacts:
     paths:
     - results


### PR DESCRIPTION
There is a known issue where Selenium Webdriver causes Firefox 47.0 to crash.

* https://bugzilla.mozilla.org/show_bug.cgi?id=1278605#c0

I'll file a new issue to unpin Firefox once a new version of the Python bindings are rolled out.