### PR TITLE
Update pytest and request

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
 bidpom
 pypom
-pytest==3.0.1
+pytest~=3.0.0
 pytest-selenium
 pytest-xdist==1.15.0
-requests==2.11.0
+requests==2.11.1


### PR DESCRIPTION
Specifically, grab the latest for requests, but version-match for pytest (currently at 3.0.2, and will be picked up with this change), so we automatically pick up any point-release versions.

@rbillings / @karlht r?